### PR TITLE
Update PlayerState.cs

### DIFF
--- a/MPTickBar/Source/State/PlayerState.cs
+++ b/MPTickBar/Source/State/PlayerState.cs
@@ -31,7 +31,7 @@ namespace MPTickBar
 
         public static byte LucidDreamingRegenStackMax => 2;
 
-        public bool IsPlayingAsBlackMage => (this.ClientState != null) && (this.Player != null) && this.ClientState.IsLoggedIn && (this.Player.ClassJob?.Id == 25);
+        public bool IsPlayingAsBlackMage => (this.ClientState != null) && (this.Player != null) && this.ClientState.IsLoggedIn;
 
         public bool IsInCombat => this.CheckCondition(new[] { ConditionFlag.InCombat });
 


### PR DESCRIPTION
removed the check for Black Mage. This plugin will work as a generic mana tick timer for any job with the additional BLM options set to hidden. There shouldn't be a reason to lock that function behind one job. DRK especially benefits from having the ability to track mp ticks.