### PR TITLE
update network state regardless of player job

### DIFF
--- a/MPTickBar/Source/State/PlayerState.cs
+++ b/MPTickBar/Source/State/PlayerState.cs
@@ -73,7 +73,7 @@ namespace MPTickBar
 
         public bool CheckPlayerId(uint targetActorId) => (this.IsPlayingAsBlackMage || this.IsPlayingWithOtherJobs) && this.Player.IsValid() && !this.IsDead.Current && (this.Player.ObjectId == targetActorId);
 
-        public bool CheckPlayerStatus(int hp, int mp) => (this.IsPlayingAsBlackMage || this.IsPlayingWithOtherJobs) && !this.IsDead.Current && (this.Player.CurrentHp == hp) && (this.Player.CurrentMp == mp);
+        public bool CheckPlayerStatus(int hp, int mp) => !this.IsDead.Current && (this.Player.CurrentHp == hp) && (this.Player.CurrentMp == mp);
 
         private class Data<T> where T : struct
         {


### PR DESCRIPTION
The /mptbcd command generates a countdown that starts just after a
network tick. This can be useful even if you're not playing black mage,
as it allows a countdown that will line up with server tick and get
everyone aligned.

This command currently doesn't work for jobs other than black mage or
(if the full plugin is enabled) dark knight.

This is because the countdown status relies on the progress bar state,
which itself relies on the network state. The network state is only
updated when CheckPlayerStatus returns true. This function is only
called to update the network state, and it is disabled when the player
is not on the appropriate class.

Fix this by changing the function to ignore the player class, and always
return true. This makes the network state update, and allows everything
else to continue.

This should fix it so that the mptbcd command functions nicely for all
jobs.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
