### PR TITLE
Hide mp tick bar in pvp

### DIFF
--- a/MPTickBar/Plugin/MPTickBarPluginUI.cs
+++ b/MPTickBar/Plugin/MPTickBarPluginUI.cs
@@ -542,6 +542,7 @@ namespace MPTickBar
 
             var isMPTickBarWindowVisible =
                 (!this.PlayerState.IsBetweenAreas) && (!this.PlayerState.IsOccupied) &&
+                (!this.PlayerState.IsPvP) &&
                 (!this.Configuration.General.IsLocked
                     ||
                     (this.PlayerState.IsPlayingAsBlackMage && checkedConditionsBlackMage.Count > 0 &&

--- a/MPTickBar/State/PlayerState.cs
+++ b/MPTickBar/State/PlayerState.cs
@@ -66,6 +66,8 @@ namespace MPTickBar
 
         public bool IsOccupied => this.CheckCondition(new[] { ConditionFlag.OccupiedInCutSceneEvent, ConditionFlag.Occupied33, ConditionFlag.Occupied38, ConditionFlag.OccupiedInQuestEvent, ConditionFlag.OccupiedSummoningBell, ConditionFlag.OccupiedInEvent });
 
+        public bool IsPvP => this.ClientState.IsPvP;
+
         private bool CheckCondition(ConditionFlag[] conditionFlags) => (this.IsPlayingAsBlackMage || this.IsPlayingWithOtherJobs) && (this.Condition != null) && conditionFlags.Any(x => this.Condition[x]);
 
         public bool IsUmbralIceActivated => (this.UmbralIceStacks > 0);


### PR DESCRIPTION
MP is a special resource in PvP that doesn't regenerate at the same rate as in PvE